### PR TITLE
sort meetups by date

### DIFF
--- a/_meetup/10-May-2014.md
+++ b/_meetup/10-May-2014.md
@@ -1,6 +1,7 @@
 ---
 layout: meetup
 title: "Meetup #11 - 10 May 2014"
+date: 2014-05-10
 permalink: /meetups/10-May-2014/
 venue:
   name: "Places Restaurant and Bar"

--- a/_meetup/18-Jul-2015.md
+++ b/_meetup/18-Jul-2015.md
@@ -1,6 +1,7 @@
 ---
 layout: meetup
 title: "Meetup #13 - 18 Jul 2015"
+date: 2015-07-18
 permalink: /meetups/18-Jul-2015/
 venue:
   name: "Leapfrog Technology"

--- a/_meetup/23-Aug-2014.md
+++ b/_meetup/23-Aug-2014.md
@@ -1,6 +1,7 @@
 ---
 layout: meetup
 title: "Meetup #12 - 23 Aug 2014"
+date: 2014-08-23
 permalink: /meetups/23-Aug-2014/
 venue:
   name: "Leapfrog Technology"

--- a/_meetup/25-Jan-2014.md
+++ b/_meetup/25-Jan-2014.md
@@ -1,6 +1,7 @@
 ---
 layout: meetup
 title: "Meetup #9 - 25 Jan 2014"
+date: 2014-01-25
 permalink: /meetups/25-Jan-2014/
 venue:
   name: "Braindigit IT Solutions"

--- a/_meetup/4-May-2014.md
+++ b/_meetup/4-May-2014.md
@@ -1,6 +1,7 @@
 ---
 layout: meetup
 title: "Geek Meetup - with Paul Tarjan"
+date: 2014-05-04
 permalink: /meetups/4-May-2014-Paul-Tarjan/
 venue:
   name: "Smart Samaj"

--- a/_meetup/8-Mar-2014.md
+++ b/_meetup/8-Mar-2014.md
@@ -1,6 +1,7 @@
 ---
 layout: meetup
 title: "Meetup #10 - 8 Mar 2014"
+date: 2014-03-08
 permalink: /meetups/8-Mar-2014/
 venue:
   name: "Places Restaurant and Bar"

--- a/index.html
+++ b/index.html
@@ -5,8 +5,9 @@ layout: default
 
   <h1>Meetups</h1>
 
+  {% assign sortedMeetups = site.meetup | sort: 'date' | reverse %}
   <ul class="post-list">
-    {% for meetup in site.meetup %}
+    {% for meetup in sortedMeetups %}
       <li>
           <a class="post-link" href="{{ meetup.url | prepend: site.baseurl }}">{{ meetup.title }}</a>
       </li>
@@ -14,7 +15,6 @@ layout: default
   </ul>
 
   <h2>Posts</h2>
-
   <ul class="post-list">
     {% for meetup in site.posts %}
       <li>

--- a/index.html
+++ b/index.html
@@ -16,9 +16,9 @@ layout: default
 
   <h2>Posts</h2>
   <ul class="post-list">
-    {% for meetup in site.posts %}
+    {% for post in site.posts %}
       <li>
-          <a class="post-link" href="{{ meetup.url | prepend: site.baseurl }}">{{ meetup.title }}</a>
+          <a class="post-link" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
       </li>
     {% endfor %}
   </ul>


### PR DESCRIPTION
fixes https://github.com/developers-nepal/php/issues/7 .

added one more commit that fixes the naming conventions. "Posts" were named as "meetups" in a sub-loop
